### PR TITLE
lsi2c: Replace error() by fprintf, drop error.h

### DIFF
--- a/libi2cdev/access.c
+++ b/libi2cdev/access.c
@@ -16,7 +16,6 @@
 
 #include "busses.h"
 #include "data.h"
-#include "error.h"
 #include "sysfs.h"
 
 #include "i2cdiscov.h"

--- a/libi2cdev/i2c-bus-parser.c
+++ b/libi2cdev/i2c-bus-parser.c
@@ -27,7 +27,6 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <error.h>
 #include <alloca.h>
 #include <search.h>
 

--- a/libi2cdev/i2c-dev-path.c
+++ b/libi2cdev/i2c-dev-path.c
@@ -11,7 +11,6 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
-#include <error.h>
 
 #include <linux/limits.h>
 

--- a/libi2cdev/i2c-error.c
+++ b/libi2cdev/i2c-error.c
@@ -9,7 +9,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <error.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdarg.h>

--- a/libi2cdev/init.c
+++ b/libi2cdev/init.c
@@ -16,10 +16,8 @@
 #include <errno.h>
 #include <dirent.h>
 #include <unistd.h>
-#include <error.h>
 #include <limits.h>
 #include <ctype.h>
-#include <error.h>
 #include <fcntl.h>
 #include <assert.h>
 

--- a/libi2cdev/sysfs.c
+++ b/libi2cdev/sysfs.c
@@ -17,7 +17,6 @@
 #include <assert.h>
 #include <string.h>
 #include <fcntl.h>
-#include <error.h>
 #include <errno.h>
 
 #include <sys/types.h>

--- a/lsi2c/lsi2c.c
+++ b/lsi2c/lsi2c.c
@@ -38,7 +38,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <error.h>
 #include <getopt.h>
 #include <stdbool.h>
 
@@ -205,7 +204,8 @@ static int read_config_file(const char *config_file_name)
         if (err < 0) {
             err = -err;
         }
-        error(0, err, "Failed to initialize i2cdevices");
+        fflush(stdout);
+        fprintf(stderr, "Failed to initialize i2cdevices: %s", strerror(err));
         if (config_file) {
             fclose(config_file);
         }


### PR DESCRIPTION
The MUSL C library doesn't support error.h. Because the only usage of this is the *error* function in lsi2c.c, this gets replaced by a *fprintf*. This doesn't print the program name, but keeps the message and the error description.